### PR TITLE
Add missing placeholder tags in localgov_skeleton

### DIFF
--- a/templates/system/html.html.twig
+++ b/templates/system/html.html.twig
@@ -30,6 +30,8 @@
   <head>
     <head-placeholder token="{{ placeholder_token }}">
     <title>{{ head_title|safe_join(' | ') }}</title>
+    <css-placeholder token="{{ placeholder_token }}">
+    <js-placeholder token="{{ placeholder_token }}">
   </head>
 
   <body{{ attributes }}>
@@ -44,5 +46,6 @@
     {{ page }}
     {{ page_bottom }}
 
+    <js-bottom-placeholder token="{{ placeholder_token }}">
   </body>
 </html>


### PR DESCRIPTION
Fix #3

Adds the css, js and js-bottom placeholder tags to html.html.twig