### PR TITLE
format templates to better follow coding standards

### DIFF
--- a/templates/block/services-cta-block.html.twig
+++ b/templates/block/services-cta-block.html.twig
@@ -29,13 +29,13 @@
 {% block content %}
 <nav aria-label="Section Navigation">
   <div>
-  {% for button in buttons %}
-    <div>
-      <a href="{{ button.url }}" class="{{ button.type }}">
-        <span>{{ button.title }}</span>
-      </a>
-    </div>
-  {% endfor %}
+    {% for button in buttons %}
+      <div>
+        <a href="{{ button.url }}" class="{{ button.type }}">
+          <span>{{ button.title }}</span>
+        </a>
+      </div>
+    {% endfor %}
   </div>
   <hr />
 </nav>

--- a/templates/facets/facets-item-list.html.twig
+++ b/templates/facets/facets-item-list.html.twig
@@ -28,19 +28,21 @@
   {% if facet.widget.type %}
     {%- set attributes = attributes.addClass('item-list__' ~ facet.widget.type) %}
   {% endif %}
-  {% if items or empty %}
-  {%- if title is not empty -%}
-    <h3>{{ title }}</h3>
-  {%- endif -%}
 
-  {%- if items -%}
-  <{{ list_type }}{{ attributes.addClass('facet-filter-checkboxes') }}>
-  {%- for item in items -%}
-    <li{{ item.attributes }}>{{ item.value }}</li>
-  {%- endfor -%}
-</{{ list_type }}>
-  {%- else -%}
-    {{- empty -}}
+  {% if items or empty %}
+    {%- if title is not empty -%}
+      <h3>{{ title }}</h3>
     {%- endif -%}
+
+    {%- if items -%}
+      <{{ list_type }}{{ attributes.addClass('facet-filter-checkboxes') }}>
+        {%- for item in items -%}
+          <li{{ item.attributes }}>{{ item.value }}</li>
+        {%- endfor -%}
+      </{{ list_type }}>
+    {%- else -%}
+      {{- empty -}}
+    {%- endif -%}
+
   {%- endif %}
 </div>

--- a/templates/field/field--clean.html.twig
+++ b/templates/field/field--clean.html.twig
@@ -47,6 +47,7 @@
   'field--label-' ~ label_display,
 ]
 %}
+
 {%
   set title_classes = [
   'field__label',

--- a/templates/field/field.html.twig
+++ b/templates/field/field.html.twig
@@ -46,9 +46,9 @@
 
 {% if label_hidden %}
 
-    {% for item in items %}
-      {{ item.content }}
-    {% endfor %}
+  {% for item in items %}
+    {{ item.content }}
+  {% endfor %}
  
 {% else %}
   <div{{ attributes }}>

--- a/templates/field/image.html.twig
+++ b/templates/field/image.html.twig
@@ -10,4 +10,4 @@
  * @see template_preprocess_image()
  */
 #}
-<img{{ attributes }} class="" />
+<img{{ attributes }} />

--- a/templates/navigation/breadcrumb.html.twig
+++ b/templates/navigation/breadcrumb.html.twig
@@ -12,14 +12,13 @@
 <nav aria-label="breadcrumb">
   <ol>
     {% for key, item in breadcrumb %}
-    {% if item.url %}
-    <li><a href="{{ item.url }}">{{ item.text }}</a></li>
-    {% else %}
-    <li>{{ item.text }}</li>
-    {% endif %}
+      {% if item.url %}
+        <li><a href="{{ item.url }}">{{ item.text }}</a></li>
+      {% else %}
+        <li>{{ item.text }}</li>
+      {% endif %}
     {% endfor %}
   </ol>
 </nav>
-
 
 {% endif %}

--- a/templates/system/page.html.twig
+++ b/templates/system/page.html.twig
@@ -59,7 +59,7 @@
 
 {% block sitewide_alert %}
  {{ sitewide_alert }}
-{% endblock%}
+{% endblock %}
 
 {% block unpublished_banner %}
   {% if unpublished_banner %}


### PR DESCRIPTION
Some small fixes here to follow Twig/Drupal coding standards a little more and to make the template code a little easier to read.